### PR TITLE
Only set authorization information in options when defined by user

### DIFF
--- a/server/services/GoService.js
+++ b/server/services/GoService.js
@@ -72,12 +72,16 @@ export default class GoService extends Service {
   getAllPipelines() {
     let options = {
       uri: this.baseUrl + '/pipelines.xml',
-      rejectUnauthorized: false,
-      auth: {
+      rejectUnauthorized: false
+    };
+    
+    if (this.user !== undefined && this.user !== null && this.user !== '') {
+      options.auth = {
         user: this.user,
         pass: this.password
       }
-    };
+    }
+    
     return rp(options)
       .then((res) => {
         let pipelines = [];
@@ -121,12 +125,16 @@ export default class GoService extends Service {
     let options = {
       uri: this.baseUrl + '/pipelines/' + name + '/history/0',
       json: true,
-      rejectUnauthorized: false,
-      auth: {
+      rejectUnauthorized: false
+    };
+    
+    if (this.user !== undefined && this.user !== null && this.user !== '') {
+      options.auth = {
         user: this.user,
         pass: this.password
       }
-    };
+    }
+    
     return rp(options)
       .then(res => this._goPipelinesToPipelineResult(res.pipelines.slice(0, 5)))
       .catch((err) => {


### PR DESCRIPTION
If the gocd server is not secured by username/password the authentication information mus not be set in the request. Otherwise the request to gocd fails. To enable access to unsecured gocd servers the authentication information must only be set when defined by the user.