### PR TITLE
Retrieve pause info from go dashboard endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To configure test reports, go to `http://localhost:3000/test-results?admin`. Cli
 ![Test reports](https://github.com/karmats/gocd-monitor/blob/gh-pages/images/test-report.png?raw=true)
 
 ## How it works
-The server polls the go server every `goPollingInterval` seconds. The results are then reported to the client using [socket.io](http://socket.io/). The pipelines are refreshed once every day.
+The server polls the go server every `goPollingInterval` seconds. The results are then reported to the client using [socket.io](http://socket.io/). The pipelines and its pause info are refreshed once every day.
 
 ## Development
 To run the application in development mode, open a terminal and enter `npm run dev-start`. The server and client will be rebuilt when a js or jsx-file changes.

--- a/client/components/Pipeline.jsx
+++ b/client/components/Pipeline.jsx
@@ -83,7 +83,7 @@ export default class Pipeline extends React.Component {
    * @return  {string}  Status paused, building, failed or passed
    */
   static status(pipeline) {
-    if (pipeline.paused) {
+    if (pipeline.pauseinfo.paused) {
       return 'paused';
     } else if (pipeline.stageresults.some(result => result.status === 'building')) {
       return 'building';
@@ -123,7 +123,7 @@ export default class Pipeline extends React.Component {
               return c.name;
             }
             return p;
-          }, ' ') : ' '}</span>
+          }, ' ') : (status === 'paused' ? pipeline.pauseinfo.pause_reason : ' ')}</span>
         </p>
         <p className="right">
           {
@@ -175,7 +175,7 @@ export default class Pipeline extends React.Component {
               </p>
               <p>
                 <i className="mdi mdi-worker mdi-24px"></i>
-                <span>{pipeline.author}</span>
+                <span>{status === 'paused' ? pipeline.pauseinfo.paused_by : pipeline.author}</span>
               </p>
             </div>
             {stages}

--- a/client/components/Pipeline.jsx
+++ b/client/components/Pipeline.jsx
@@ -83,7 +83,7 @@ export default class Pipeline extends React.Component {
    * @return  {string}  Status paused, building, failed or passed
    */
   static status(pipeline) {
-    if (pipeline.pauseinfo.paused) {
+    if (pipeline.pauseinfo && pipeline.pauseinfo.paused) {
       return 'paused';
     } else if (pipeline.stageresults.some(result => result.status === 'building')) {
       return 'building';

--- a/server/services/GoBuildService.js
+++ b/server/services/GoBuildService.js
@@ -32,6 +32,42 @@ export default class GoBuildService {
   }
 
   /**
+   * Retrive all pipelines paused info.
+   * 
+   * @return {Promise<Object}   
+   * Example 
+   * { 
+   *   'pipeline1' : {
+   *     paused : false,
+   *     paused_by: null,
+   *     pause_reason: null},
+   *   'pipeline2' : {
+   *     paused : true,
+   *     paused_by : 'me',
+   *     pause_reason : 'Under construction'
+   *   }
+   * }
+   */
+  getPipelinesPauseInfo() {
+    const options = Util.createRequestOptions(`${this.conf.serverUrl}/go/api/dashboard`, this.conf, true, {'Accept' : 'application/vnd.go.cd.v1+json'});
+
+    return rp(options)
+      .then((res) => {
+        // Return map with pipeline name as key.
+        return res._embedded.pipeline_groups.reduce((acc, curr) => {
+          curr._embedded.pipelines.forEach((cp) => {
+            acc[cp.name] = cp.pause_info;
+          });
+          return acc;
+        }, {});
+      })
+      .catch((err) => {
+        Logger.error('Failed to retrieve pipeline pause information');
+        return {};
+      })
+  }
+
+  /**
    * @param   {string}          name  Name of the pipeline
    * @returns {Promise<Object>}       Pipeline instance. 
    * Example 

--- a/server/utils/GoPipelineParser.js
+++ b/server/utils/GoPipelineParser.js
@@ -31,7 +31,6 @@ export default class GoPipelineParser {
     *    buildtime : 1457085089646,
     *    author: 'Bobby Malone',
     *    counter: 255,
-    *    paused: false,
     *    health: 2,
     *    stageresults: [
     *      {
@@ -82,9 +81,6 @@ export default class GoPipelineParser {
       })
       return stageResult;
     });
-
-    // Pipeline is paused if none of the stagues can run and the pipeline isn't building
-    result.paused = !result.stageresults.some(stageResult => stageResult.status === 'building') && latestPipelineResult.stages.every((stage) => stage.can_run === false);
 
     // Health = number of pipelines failed
     result.health = pipelines.reduce((p, c) => {

--- a/server/utils/Util.js
+++ b/server/utils/Util.js
@@ -12,11 +12,12 @@ export default class Util {
    * 
    * @return  {Object}   Request configuration
    */
-  static createRequestOptions(url, config, json = false) {
+  static createRequestOptions(url, config, json = false, headers = {}) {
     const options = {
       uri: url,
       rejectUnauthorized: false,
-      json: json
+      json: json,
+      headers: headers
     };
     if (config.user && config.password) {
       options.auth = {

--- a/spec/GoBuildServiceSpec.js
+++ b/spec/GoBuildServiceSpec.js
@@ -110,4 +110,27 @@ describe('GoBuildService spec', () => {
 
   });
 
+  describe('#getPipelinesPauseInfo()', () => {
+
+    it('should retrieve pipeline pause info', (done) => {
+      mockedRequestPromise = Promise.resolve(JSON.parse(fs.readFileSync(__dirname + '/data/dashboard.json', 'utf-8')));
+      let pipelinePromise = new GoBuildService(config).getPipelinesPauseInfo();
+
+      expect(pipelinePromise).to.eventually.be.ok;
+      expect(pipelinePromise).to.eventually.have.property('first');
+      expect(pipelinePromise).to.eventually.have.deep.property('first.paused', true);
+      expect(pipelinePromise).to.eventually.have.deep.property('first.paused_by', 'admin');
+      expect(pipelinePromise).to.eventually.have.deep.property('first.pause_reason', 'under construction').and.notify(done);
+    });
+
+    it('should return empty object if promise is rejected', (done) => {
+      mockedRequestPromise = Promise.reject({ message: 'Fake error'});
+      let pipelinePromise = new GoBuildService(config).getPipelinesPauseInfo();
+
+      expect(pipelinePromise).to.eventually.be.ok;
+      expect(pipelinePromise).to.eventually.be.empty.and.notify(done);
+    });
+
+  });
+
 });

--- a/spec/PipelineComponentSpec.js
+++ b/spec/PipelineComponentSpec.js
@@ -39,9 +39,11 @@ describe('PipelineComponent spec', () => {
       expect(Pipeline.status(pipeline)).to.be.equal('passed');
     });
 
-    it('should be paused when all pipeline is paused', () => {
+    it('should be paused when pause info is paused', () => {
       const pipeline = {
-        paused: true,
+        pauseinfo: {
+          paused: true
+        },
         stageresults: [{ status: 'passed' }, { status: 'passed' }]
       };
 

--- a/spec/data/dashboard.json
+++ b/spec/data/dashboard.json
@@ -1,0 +1,130 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://ci.example.com/go/api/dashboard"
+    },
+    "doc": {
+      "href": "http://api.go.cd/current/#dashboard"
+    }
+  },
+  "_embedded": {
+    "pipeline_groups": [
+      {
+        "_links": {
+          "self": {
+            "href": "https://ci.example.com/go/api/config/pipeline_groups"
+          },
+          "doc": {
+            "href": "http://api.go.cd/current/#pipeline-groups"
+          }
+        },
+        "name": "first",
+        "_embedded": {
+          "pipelines": [
+            {
+              "_links": {
+                "self": {
+                  "href": "https://ci.example.com/go/api/pipelines/first/history"
+                },
+                "doc": {
+                  "href": "http://api.go.cd/current/#pipelines"
+                },
+                "settings_path": {
+                  "href": "https://ci.example.com/go/admin/pipelines/first/general"
+                },
+                "trigger": {
+                  "href": "https://ci.example.com/go/api/pipelines/first/schedule"
+                },
+                "trigger_with_options": {
+                  "href": "https://ci.example.com/go/api/pipelines/first/schedule"
+                },
+                "pause": {
+                  "href": "https://ci.example.com/go/api/pipelines/first/pause"
+                },
+                "unpause": {
+                  "href": "https://ci.example.com/go/api/pipelines/first/unpause"
+                }
+              },
+              "name": "first",
+              "locked": false,
+              "pause_info": {
+                "paused": true,
+                "paused_by": "admin",
+                "pause_reason": "under construction"
+              },
+              "_embedded": {
+                "instances": [
+                  {
+                    "_links": {
+                      "self": {
+                        "href": "https://ci.example.com/go/api/pipelines/first/instance/2"
+                      },
+                      "doc": {
+                        "href": "http://api.go.cd/current/#get-pipeline-instance"
+                      },
+                      "history_url": {
+                        "href": "https://ci.example.com/go/api/pipelines/first/history"
+                      },
+                      "vsm_url": {
+                        "href": "https://ci.example.com/go/pipelines/value_stream_map/first/2"
+                      },
+                      "compare_url": {
+                        "href": "https://ci.example.com/go/compare/first/1/with/2"
+                      },
+                      "build_cause_url": {
+                        "href": "https://ci.example.com/go/pipelines/first/2/build_cause"
+                      }
+                    },
+                    "label": "2",
+                    "schedule_at": "2015-09-18T11:11:36.378Z",
+                    "triggered_by": "admin",
+                    "_embedded": {
+                      "stages": [
+                        {
+                          "_links": {
+                            "self": {
+                              "href": "https://ci.example.com/go/api/stages/first/2/stage1/2"
+                            },
+                            "doc": {
+                              "href": "http://api.go.cd/current/#get-stage-instance"
+                            }
+                          },
+                          "name": "stage1",
+                          "status": "Building",
+                          "previous_stage": {
+                            "_links": {
+                              "self": {
+                                "href": "https://ci.example.com/go/api/stages/first/1/stage1/2"
+                              },
+                              "doc": {
+                                "href": "http://api.go.cd/current/#get-stage-instance"
+                              }
+                            },
+                            "name": "stage1",
+                            "status": "Passed"
+                          }
+                        },
+                        {
+                          "_links": {
+                            "self": {
+                              "href": "https://ci.example.com/go/api/stages/first/2/stage2/1"
+                            },
+                            "doc": {
+                              "href": "http://api.go.cd/current/#get-stage-instance"
+                            }
+                          },
+                          "name": "stage2",
+                          "status": "Passed"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Retrieve go dashboard data once every day to see which pipelines that are paused, and why. If a pipeline is paused, reason why is displayed above stage indicators

This fixes #6 