### PR TITLE
A simple regex filter for pipelines

### DIFF
--- a/client/components/Configuration.jsx
+++ b/client/components/Configuration.jsx
@@ -4,7 +4,9 @@
 
 import React from 'react';
 
-import { Divider, List, ListItem, Popover, Subheader, Toggle } from 'material-ui';
+import {Divider, List, ListItem, Popover, Subheader, Toggle} from 'material-ui';
+
+import RegexPipelineFilter from './RegexPipelineFilter';
 
 export default class Configuration extends React.Component {
 
@@ -17,8 +19,9 @@ export default class Configuration extends React.Component {
       // Configurable sort order
       currentSortOrder: props.sortOrder,
       // List of sort order options openened or not
-      sortOrderListOpened: false
-    }
+      sortOrderListOpened: false,
+      filterRegexProps: props.filterRegexProps
+    };
   }
 
   componentDidMount() {
@@ -30,17 +33,17 @@ export default class Configuration extends React.Component {
   // Setup and sort pipelines by name
   setupPipelines(pipelines, disabledPipelines) {
     return pipelines
-    .map((p) => {
-      return { name: p, active: disabledPipelines.indexOf(p) < 0 }
-    })
-    .sort((a,b) => a.name > b.name ? 1 : -1);
+      .map((p) => {
+        return {name: p, active: disabledPipelines.indexOf(p) < 0}
+      })
+      .sort((a, b) => a.name > b.name ? 1 : -1);
   }
 
   // Toggles a pipeline on/off
   togglePipeline(p, event) {
     this.props.onTogglePipeline(p.name, event.target.checked);
   }
-  
+
   // Sort order changed
   sortOrderChanged(sortOrder) {
     this.setState({
@@ -63,45 +66,69 @@ export default class Configuration extends React.Component {
     });
   }
 
-  render() {
-    
-    let sortOrders = 
-      (<List>
-        {
-          this.props.sortOrders.map((s) => {
-            return <ListItem key={s.name} primaryText={s.label} onTouchTap={this.sortOrderChanged.bind(this, s)}  />
-        }
-      ) }
-      </List>
-    );
+  updateFilterRegexProps() {
+    console.log("State from config: " + this.state.filterRegexActive, this.state.filterRegex)
+    this.props.onFilterRegexPropsChange({
+      active: this.state.filterRegexActive,
+      value: this.state.filterRegex
+    })
+  }
 
-    let pipelines = 
-    (
-      <List>
-        <Subheader>Filter Pipelines</Subheader>
-        { this.state.pipelines.map((p) => {
-            return <ListItem key={p.name} primaryText={p.name} rightToggle={<Toggle defaultToggled={p.active} onToggle={this.togglePipeline.bind(this, p)} />} />
-        }) }
-        <Popover
-          open={this.state.sortOrderListOpened}
-          anchorEl={this.state.anchorEl}
-          anchorOrigin={{horizontal: 'left', vertical: 'center'}}
-          targetOrigin={{horizontal: 'left', vertical: 'center'}}
-          onRequestClose={this.closeSortOrderList.bind(this)}
-          useLayerForClickAway={true}
-        >
-          {sortOrders}
-        </Popover>
-      </List>
-    );
+  updateFilterRegex(e) {
+    this.setState({
+      filterRegex: e.target.value
+    });
+  }
+
+  updateFilterRegexActive(e) {
+    this.setState({
+      filterRegexActive: e.target.checked
+    });
+  }
+
+  render() {
+
+    let sortOrders =
+      (<List>
+          {
+            this.props.sortOrders.map((s) => {
+                return <ListItem key={s.name} primaryText={s.label} onTouchTap={this.sortOrderChanged.bind(this, s)}/>
+              }
+            ) }
+        </List>
+      );
+
+    let pipelines =
+      (
+        <List>
+          <Subheader>Toggle Pipelines</Subheader>
+
+          { this.state.pipelines.map((p) => {
+            return <ListItem key={p.name} primaryText={p.name}
+                             rightToggle={<Toggle defaultToggled={p.active} onToggle={this.togglePipeline.bind(this, p)} />}/>
+          }) }
+          <Popover
+            open={this.state.sortOrderListOpened}
+            anchorEl={this.state.anchorEl}
+            anchorOrigin={{horizontal: 'left', vertical: 'center'}}
+            targetOrigin={{horizontal: 'left', vertical: 'center'}}
+            onRequestClose={this.closeSortOrderList.bind(this)}
+            useLayerForClickAway={true}
+          >
+            {sortOrders}
+          </Popover>
+        </List>
+      );
 
     return (
       <div>
         <List>
           <Subheader>General</Subheader>
-          <ListItem primaryText="Sort Order" secondaryText={this.state.currentSortOrder.label} onTouchTap={this.openSortOrderList.bind(this)} />
-        <Divider />
+          <ListItem primaryText="Sort Order" secondaryText={this.state.currentSortOrder.label}
+                    onTouchTap={this.openSortOrderList.bind(this)}/>
+          <Divider />
         </List>
+        <RegexPipelineFilter filterRegexProps={this.state.filterRegexProps} onFilterRegexPropsChange={this.props.onFilterRegexPropsChange}/>
         {pipelines}
       </div>
     );

--- a/client/components/Configuration.jsx
+++ b/client/components/Configuration.jsx
@@ -30,6 +30,7 @@ export default class Configuration extends React.Component {
     });
   }
 
+
   // Setup and sort pipelines by name
   setupPipelines(pipelines, disabledPipelines) {
     return pipelines
@@ -67,7 +68,6 @@ export default class Configuration extends React.Component {
   }
 
   updateFilterRegexProps() {
-    console.log("State from config: " + this.state.filterRegexActive, this.state.filterRegex)
     this.props.onFilterRegexPropsChange({
       active: this.state.filterRegexActive,
       value: this.state.filterRegex

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -62,7 +62,7 @@ export default class Main extends React.Component {
       // Snackbar message
       showMessage: false,
       filterRegexProps: {
-        active: true,
+        active: false,
         value: ''
       },
       message: ''
@@ -104,7 +104,11 @@ export default class Main extends React.Component {
     this.socket.emit('pipelines:get');
   }
 
-  updateDisabledPipelinesOnSave(settings) {
+  /**
+   * Update disabled pipelines based upon regex requirement
+   * @param {Object} configurationProperties to update
+   */
+  updateDisabledPipelines(settings) {
     const regexFilter = new RegExp(settings.filterRegexProps.value);
     settings.disabledPipelines = this.state.pipelineNames.filter((p) => {
       if (regexFilter.test(p)){
@@ -112,7 +116,6 @@ export default class Main extends React.Component {
       }
       return settings.filterRegexProps.active;
     });
-    this.saveSettings(settings);
   }
 
   saveSettings(settings) {
@@ -167,6 +170,7 @@ export default class Main extends React.Component {
 
   updateFilterRegexProps(filterRegexProps) {
     this.configurationProperties.filterRegexProps = filterRegexProps;
+    this.updateDisabledPipelines(this.configurationProperties);
   }
 
   /**
@@ -248,7 +252,7 @@ export default class Main extends React.Component {
       <FlatButton
         label="Save"
         primary={true}
-        onTouchTap={this.updateDisabledPipelinesOnSave.bind(this, this.configurationProperties)}
+        onTouchTap={this.saveSettings.bind(this, this.configurationProperties)}
       />
     ];
 

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -33,7 +33,7 @@ const styles = {
 const sortOrders = [{
   name : 'buildtime',
   label: 'Build time'
-}, 
+},
 {
   name: 'status',
   label: 'Status (building, failed, passed, paused)'
@@ -61,6 +61,10 @@ export default class Main extends React.Component {
       settingsDialogOpened: false,
       // Snackbar message
       showMessage: false,
+      filterRegexProps: {
+        active: true,
+        value: ''
+      },
       message: ''
     };
   }
@@ -90,7 +94,8 @@ export default class Main extends React.Component {
         this.setState({
           pipelines: this.sortPipelines(pipelines, settings.disabledPipelines, settings.sortOrder),
           sortOrder : sortOrders.filter(s => settings.sortOrder === s.name)[0],
-          disabledPipelines: settings.disabledPipelines
+          disabledPipelines: settings.disabledPipelines,
+          filterRegexProps: settings.filterRegexProps
         });
       }
     });
@@ -99,10 +104,22 @@ export default class Main extends React.Component {
     this.socket.emit('pipelines:get');
   }
 
+  updateDisabledPipelinesOnSave(settings) {
+    const regexFilter = new RegExp(settings.filterRegexProps.value);
+    settings.disabledPipelines = this.state.pipelineNames.filter((p) => {
+      if (regexFilter.test(p)){
+        return !settings.filterRegexProps.active;
+      }
+      return settings.filterRegexProps.active;
+    });
+    this.saveSettings(settings);
+  }
+
   saveSettings(settings) {
     this.socket.emit('settings:update', {
       sortOrder: settings.sortOrder.name,
-      disabledPipelines: settings.disabledPipelines
+      disabledPipelines: settings.disabledPipelines,
+      filterRegexProps: settings.filterRegexProps
     });
     this.setState({
       settingsDialogOpened: false,
@@ -124,8 +141,9 @@ export default class Main extends React.Component {
     // Init the configuration properties
     this.configurationProperties = {
       disabledPipelines: this.state.disabledPipelines,
-      sortOrder: this.state.sortOrder
-    }	
+      sortOrder: this.state.sortOrder,
+      filterRegexProps: this.state.filterRegexProps
+    }
     this.setState({
       settingsDialogOpened: true
     });
@@ -133,7 +151,7 @@ export default class Main extends React.Component {
 
   /**
    * Show/hide a pipeline. Used in configuration dialog
-   * 
+   *
    * @param {string}  pipelineName  Name of the pipeline to toggle
    * @param {boolean} active        Weather to show or hide it
    */
@@ -147,9 +165,13 @@ export default class Main extends React.Component {
     this.configurationProperties.disabledPipelines = disabledPipelines;
   }
 
+  updateFilterRegexProps(filterRegexProps) {
+    this.configurationProperties.filterRegexProps = filterRegexProps;
+  }
+
   /**
    * Change current pipeline sort order
-   * 
+   *
    * @param {Object}  newSortOrder  The sort order to change to, @see const sortOrders
    */
   changeSortOrder(newSortOrder) {
@@ -158,11 +180,11 @@ export default class Main extends React.Component {
 
   /**
    * Sort pipelines by date and filter out pipelines without data
-   * 
+   *
    * @param   {Array}   pipelines         The pipelines to sort
    * @param   {Array}   disabledPipelines Pipelines that are disabled
    * @param   {string}  sortOrder         The sort order, 'buildtime' or 'status'
-   * @return  {Array}   Sorted pipelines  
+   * @return  {Array}   Sorted pipelines
    */
   sortPipelines(pipelines, disabledPipelines, sortOrder) {
     const activePipelines = pipelines.filter(p => p && p.name && disabledPipelines.indexOf(p.name) < 0);
@@ -226,7 +248,7 @@ export default class Main extends React.Component {
       <FlatButton
         label="Save"
         primary={true}
-        onTouchTap={this.saveSettings.bind(this, this.configurationProperties)}
+        onTouchTap={this.updateDisabledPipelinesOnSave.bind(this, this.configurationProperties)}
       />
     ];
 
@@ -252,7 +274,7 @@ export default class Main extends React.Component {
             actions={settingsActions}
             autoScrollBodyContent={true}
             onRequestClose={this.closeSettings.bind(this)}>
-            <Configuration pipelines={this.state.pipelineNames} sortOrder={this.state.sortOrder} disabledPipelines={this.state.disabledPipelines} sortOrders={sortOrders} onSortOrderChange={this.changeSortOrder.bind(this)} onTogglePipeline={this.togglePipeline.bind(this)} />
+            <Configuration pipelines={this.state.pipelineNames} sortOrder={this.state.sortOrder} disabledPipelines={this.state.disabledPipelines} filterRegexProps={this.state.filterRegexProps} sortOrders={sortOrders} onSortOrderChange={this.changeSortOrder.bind(this)} onTogglePipeline={this.togglePipeline.bind(this)} onFilterRegexPropsChange={this.updateFilterRegexProps.bind(this)} />
           </Dialog>
           <Snackbar
             open={this.state.showMessage}

--- a/client/components/RegexPipelineFilter.jsx
+++ b/client/components/RegexPipelineFilter.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import {Divider, List, ListItem, Subheader, Toggle, FlatButton} from 'material-ui';
+
+export default class RegexPipelineFilter extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {
+      filterRegexActive: props.filterRegexProps.active,
+      filterRegex: props.filterRegexProps.value
+    }
+  }
+
+  updateFilterRegexProps() {
+    console.log("State from config: " + this.state.filterRegexActive, this.state.filterRegex)
+    this.props.onFilterRegexPropsChange({
+      active: this.state.filterRegexActive,
+      value: this.state.filterRegex
+    })
+  }
+
+  updateFilterRegex(e) {
+    this.setState({
+      filterRegex: e.target.value
+    });
+  }
+
+  updateFilterRegexActive(e) {
+    this.setState({
+      filterRegexActive: e.target.checked
+    });
+  }
+
+  render() {
+    let filterByRegex = (
+      <ListItem
+        primaryText={
+          <input
+            type="text"
+            value={this.state.filterRegex}
+            onChange={this.updateFilterRegex.bind(this)}
+          />
+        }
+        rightToggle={
+          <Toggle defaultToggled={this.state.filterRegexActive} onToggle={this.updateFilterRegexActive.bind(this)}/>
+        }/>
+    );
+
+    return (
+      <List>
+        <Subheader>Filter Pipelines</Subheader>
+        {filterByRegex}
+        <ListItem
+          rightIconButton={<FlatButton
+              label="Update Regex"
+              primary={true}
+              onTouchTap={this.updateFilterRegexProps.bind(this)}
+            />}
+        />
+        <Divider />
+      </List>
+    );
+  }
+}

--- a/client/components/RegexPipelineFilter.jsx
+++ b/client/components/RegexPipelineFilter.jsx
@@ -12,7 +12,6 @@ export default class RegexPipelineFilter extends React.Component {
   }
 
   updateFilterRegexProps() {
-    console.log("State from config: " + this.state.filterRegexActive, this.state.filterRegex)
     this.props.onFilterRegexPropsChange({
       active: this.state.filterRegexActive,
       value: this.state.filterRegex


### PR DESCRIPTION
Filter pipelines by regex, very useful for toggling multiple pipelines at once. If regex toggle is applied, only pipelines matching regex will be shown. If toggle is not applied, any pipelines matching regex will not be shown.

Pipelines will only be updated with new regex if "Update Regex" is clicked and on "Save".

![regex-filter](https://cloud.githubusercontent.com/assets/5412836/19215150/e17c7196-8d5b-11e6-808c-fde50ff7483f.png)
