### PR TITLE
Adding ability to display Build Labels on Pipelines.

### DIFF
--- a/app-config.js
+++ b/app-config.js
@@ -14,6 +14,8 @@ var config = {
     // How often data from go should be refreshed in seconds
     goPollingInterval: 30,
     // If > 0 switches between pipeline and test results page every n seconds
-    switchBetweenPagesInterval: 0
+    switchBetweenPagesInterval: 0,
+    // Whether to display build labels
+    showBuildLabels: false
 }
 module.exports = config;

--- a/client/components/Pipeline.jsx
+++ b/client/components/Pipeline.jsx
@@ -40,9 +40,7 @@ const styles = {
     fontSize: '1.2em'
   },
   cardLabel: {
-    color: '#eee',
-    fontSize: '1.0em',
-    fontStyle: 'italic'
+    fontWeight: 'normal'
   },
   cardSubTitle: {
     color: '#fff',
@@ -174,19 +172,19 @@ export default class Pipeline extends React.Component {
         break;
     }
 
-    let buildTitle = pipeline.name;
+    let buildStatus = status;
 
     if (showBuildLabels) {
-      buildTitle = <div>{pipeline.name}<span style={styles.cardLabel}> : {pipeline.label}</span></div>;
+      buildStatus = <div>{status}<span style={styles.cardLabel}> : {pipeline.label}</span></div>;
     }
 
     return (
       <Card style={style} containerStyle={styles.cardContainer}>
         <CardHeader
           className="buildtitle"
-          title={buildTitle}
+          title={pipeline.name}
           titleStyle={styles.cardTitle}
-          subtitle={status}
+          subtitle={buildStatus}
           subtitleStyle={styles.cardSubTitle}>
           <i className={'mdi-weather-' + this.weatherIcon(pipeline) + ' mdi mdi-48px buildstatus'}></i>
         </CardHeader>

--- a/client/components/Pipeline.jsx
+++ b/client/components/Pipeline.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { Card, CardHeader, CardText } from 'material-ui/Card';
 import * as Colors from 'material-ui/styles/colors';
-
+import { showBuildLabels } from '../../app-config';
 
 // Weather icon indicator
 const weatherIconStatuses = ['sunny', 'partlycloudy', 'cloudy', 'cloudy', 'pouring', 'lightning'];
@@ -39,6 +39,11 @@ const styles = {
     color: '#fff',
     fontSize: '1.2em'
   },
+  cardLabel: {
+    color: '#eee',
+    fontSize: '1.0em',
+    fontStyle: 'italic'
+  },
   cardSubTitle: {
     color: '#fff',
     fontSize: '1em',
@@ -56,7 +61,7 @@ export default class Pipeline extends React.Component {
    * Calculates which weather icon to use for a pipeline based on pipeline heath.
    * This function was a bit more advanced back in the days, with api changes it got reduced to this.
    * Let's keep it for now
-   * 
+   *
    * @param   {Object}  pipeline  The pipeline
    * @return  {string}  Pre weather icon classname
    */
@@ -66,7 +71,7 @@ export default class Pipeline extends React.Component {
 
   /**
    * Calculates icon for stage visualization.
-   * 
+   *
    * @param   {Object}  stage   Stage with name and status
    * @return  {string}  Material design icon classname
    */
@@ -85,7 +90,7 @@ export default class Pipeline extends React.Component {
 
   /**
    * Calculate what status a pipeline has
-   * 
+   *
    * @param   {Object}  pipeline  The pipeline to calculate status for
    * @return  {string}  Status paused, building, failed or passed
    */
@@ -168,11 +173,18 @@ export default class Pipeline extends React.Component {
         style = styles.cardCancelled;
         break;
     }
+
+    let buildTitle = pipeline.name;
+
+    if (showBuildLabels) {
+      buildTitle = <div>{pipeline.name}<span style={styles.cardLabel}> : {pipeline.label}</span></div>;
+    }
+
     return (
       <Card style={style} containerStyle={styles.cardContainer}>
         <CardHeader
           className="buildtitle"
-          title={pipeline.name}
+          title={buildTitle}
           titleStyle={styles.cardTitle}
           subtitle={status}
           subtitleStyle={styles.cardSubTitle}>

--- a/server/utils/GoPipelineParser.js
+++ b/server/utils/GoPipelineParser.js
@@ -7,7 +7,7 @@ export default class GoPipelineParser {
 
   /**
    * Parse pipeline.xml from go server. See spec/data/pipelines.xml for example
-   * 
+   *
    * @return {Promise<Array<string>>} Array with pipeline names
    */
   static parsePipelineNames(pipelineXml) {
@@ -24,13 +24,14 @@ export default class GoPipelineParser {
 
    /**
     * @param   {Array<Object}    pipelineHistory  History for a pipeline, see spec/data/pipeline.json for example
-    * @returns {Object}          Pipeline instance. 
-    * Example 
-    * { 
+    * @returns {Object}          Pipeline instance.
+    * Example
+    * {
     *    name : 'id,
     *    buildtime : 1457085089646,
     *    author: 'Bobby Malone',
     *    counter: 255,
+    *    label: v255
     *    health: 2,
     *    stageresults: [
     *      {
@@ -48,7 +49,7 @@ export default class GoPipelineParser {
     *        status: 'building',
     *        counter: 2,
     *        jobresults: []
-    *      }] 
+    *      }]
     * }
     */
   static parsePipelineResult(pipelines) {
@@ -63,6 +64,9 @@ export default class GoPipelineParser {
 
     // Pipeline name
     result.name = latestPipelineResult.name;
+
+    // Pipeline label
+    result.label = latestPipelineResult.label;
 
     // Stage results
     result.stageresults = latestPipelineResult.stages.map((stage) => {
@@ -108,7 +112,7 @@ export default class GoPipelineParser {
     // Author = first modifcator or approver
     let author = 'Unknown';
     const validAuthor = (auth) => {
-      return auth && auth !== 'Unknown' && auth !== 'changes' && auth !== 'anonymous' && auth !== 'timer'; 
+      return auth && auth !== 'Unknown' && auth !== 'changes' && auth !== 'anonymous' && auth !== 'timer';
     }
     const buildCause = latestPipelineResult.build_cause;
     if (buildCause && buildCause.material_revisions && buildCause.material_revisions[0].modifications) {

--- a/spec/GoBuildServiceSpec.js
+++ b/spec/GoBuildServiceSpec.js
@@ -9,7 +9,7 @@ describe('GoBuildService spec', () => {
   // Chai setup
   chai.use(chaiAsPromised);
   const expect = chai.expect;
-  
+
   // Config
   const config = {
     serverUrl: 'https://ci.example.com',
@@ -60,75 +60,82 @@ describe('GoBuildService spec', () => {
 
   describe('#getAllPipelines()', () => {
 
-    it('should parse go pipelines.xml', (done) => {
+    it('should parse go pipelines.xml', () => {
       mockedRequestPromise = Promise.resolve(fs.readFileSync(__dirname + '/data/pipelines.xml', 'utf-8'));
       let pipelinesPromise = new GoBuildService(config).getAllPipelines();
 
-      expect(pipelinesPromise).to.eventually.be.ok;
-      expect(pipelinesPromise).to.eventually.have.length(2);
-      expect(pipelinesPromise).to.eventually.contain('go-pipeline-1').and.notify(done);
+      return pipelinesPromise.then(pipelines => {
+        expect(pipelines).to.be.ok;
+        expect(pipelines).to.have.length(2);
+        expect(pipelines).to.contain('go-pipeline-1');
+      });
     });
 
-    it('should return throw error if promise is rejected', (done) => {
+    it('should return throw error if promise is rejected', () => {
       mockedRequestPromise = Promise.reject({ message: 'Fake error' });
       let pipelinePromise = new GoBuildService(config).getAllPipelines();
 
-      expect(pipelinePromise).to.be.rejected.and.notify(done);
+      return expect(pipelinePromise).to.be.rejected;
     });
   });
 
   describe('#getPipelineHistory()', () => {
 
-    it('should parse go pipelines', (done) => {
+    it('should parse go pipelines', () => {
       mockedRequestPromise = Promise.resolve(JSON.parse(fs.readFileSync(__dirname + '/data/pipeline.json', 'utf-8')));
       let pipelinePromise = new GoBuildService(config).getPipelineHistory('pipeline1');
 
-      expect(pipelinePromise).to.eventually.be.ok;
-      expect(pipelinePromise).to.eventually.have.property('name');
-      expect(pipelinePromise).to.eventually.have.property('author');
-      expect(pipelinePromise).to.eventually.have.property('buildtime');
-      expect(pipelinePromise).to.eventually.have.property('counter');
-      expect(pipelinePromise).to.eventually.have.property('health').and.notify(done);
+      return pipelinePromise.then(pipeline => {
+        expect(pipeline).to.have.property("name");
+        expect(pipeline).to.have.property("author");
+        expect(pipeline).to.have.property("buildtime");
+        expect(pipeline).to.have.property("counter");
+        expect(pipeline).to.have.property("health");
+      });
     });
 
-    it('should return null if promise is rejected and pipelines are empty', (done) => {
+    it('should return null if promise is rejected and pipelines are empty', () => {
       mockedRequestPromise = Promise.reject({ message: 'Fake error' });
       let pipelinePromise = new GoBuildService(config).getPipelineHistory('pipeline1');
 
-      expect(pipelinePromise).to.eventually.be.null.and.notify(done);
+      return expect(pipelinePromise).to.eventually.be.null;
     });
 
-    it('should return last known pipeline result if promise is rejected', (done) => {
+    it('should return last known pipeline result if promise is rejected', () => {
       mockedRequestPromise = Promise.reject({ message: 'Fake error' });
       let goBuildService = new GoBuildService(config);
       let lastPipelineResult = { name: 'pipeline1', results: [] };
       goBuildService.pipelines = [lastPipelineResult, { name: 'pipeline2', results: [] }];
       let pipelinePromise = goBuildService.getPipelineHistory(lastPipelineResult.name);
 
-      expect(pipelinePromise).to.eventually.be.equal(lastPipelineResult).and.notify(done);
+      return expect(pipelinePromise).to.eventually.be.equal(lastPipelineResult);
     });
 
   });
 
   describe('#getPipelinesPauseInfo()', () => {
 
-    it('should retrieve pipeline pause info', (done) => {
+    it('should retrieve pipeline pause info', () => {
       mockedRequestPromise = Promise.resolve(JSON.parse(fs.readFileSync(__dirname + '/data/dashboard.json', 'utf-8')));
       let pipelinePromise = new GoBuildService(config).getPipelinesPauseInfo();
 
-      expect(pipelinePromise).to.eventually.be.ok;
-      expect(pipelinePromise).to.eventually.have.property('first');
-      expect(pipelinePromise).to.eventually.have.deep.nested.property('first.paused', true);
-      expect(pipelinePromise).to.eventually.have.deep.nested.property('first.paused_by', 'admin');
-      expect(pipelinePromise).to.eventually.have.deep.nested.property('first.pause_reason', 'under construction').and.notify(done);
+      return pipelinePromise.then(pipeline => {
+        expect(pipeline).to.be.ok;
+        expect(pipeline).to.have.property('first');
+        expect(pipeline).to.have.deep.nested.property('first.paused', true);
+        expect(pipeline).to.have.deep.nested.property('first.paused_by', 'admin');
+        expect(pipeline).to.have.deep.nested.property('first.pause_reason', 'under construction');
+      });
     });
 
-    it('should return empty object if promise is rejected', (done) => {
+    it('should return empty object if promise is rejected', () => {
       mockedRequestPromise = Promise.reject({ message: 'Fake error'});
       let pipelinePromise = new GoBuildService(config).getPipelinesPauseInfo();
 
-      expect(pipelinePromise).to.eventually.be.ok;
-      expect(pipelinePromise).to.eventually.be.empty.and.notify(done);
+      return pipelinePromise.then(pipeline => {
+        expect(pipeline).to.be.ok;
+        expect(pipeline).to.be.empty;
+      });
     });
 
   });

--- a/spec/GoBuildServiceSpec.js
+++ b/spec/GoBuildServiceSpec.js
@@ -88,6 +88,7 @@ describe('GoBuildService spec', () => {
       return pipelinePromise.then(pipeline => {
         expect(pipeline).to.have.property("name");
         expect(pipeline).to.have.property("author");
+        expect(pipeline).to.have.property("label");
         expect(pipeline).to.have.property("buildtime");
         expect(pipeline).to.have.property("counter");
         expect(pipeline).to.have.property("health");


### PR DESCRIPTION
Added the ability to display Build Labels on Pipelines. It can be turned on/off using `showBuildLabels` in `app-config.js` (defaults to 'off').

Labels are displayed at the end of the Build Name, separated by a colon.

Let me know if there is any preference to display the label elsewhere instead, wasn't 100% sure of the nicest place to put it, where it is works for us, but I'm open to suggestions. :)

Also fixed an issue with tests in GoBuildServiceSpec not failing when they should. When multiple assertions are made on a promise, only the last one would cause the test to fail if not true.

Everything before the last was still letting the tests pass even if the assertions weren't met.