### PR TITLE
Error retrieving pipelines when no valid author

### DIFF
--- a/server/utils/GoPipelineParser.js
+++ b/server/utils/GoPipelineParser.js
@@ -127,7 +127,7 @@ export default class GoPipelineParser {
             return c.approved_by;
           }
           return auth;
-        }, author);
+        }, 'Unknown');
       }
     }
 


### PR DESCRIPTION
> 'ERROR Failed to get pipeline history for pipeline "<pipeline-name>" returning last result, undefined: Cannot read property 'indexOf' of null

occurs when pipeline does not contain valid author information. In this case the author may be 'null'. If so the code to remove any email tag fails.

Adding default value to reduce function fixes this problem.