### PR TITLE
Show error when socket.io connection has problems

### DIFF
--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -70,6 +70,13 @@ export default class Main extends React.Component {
   }
 
   componentDidMount() {
+    // Listen for connection errors
+    this.socket.on('connect_error', (err) => {
+      this.setState({
+          showMessage: true,
+          message: "Connect Error: " + err.message
+      });
+    });
 
     // Listen for updates
     this.socket.on('pipelines:updated', (newPipelines) => {


### PR DESCRIPTION
Sometimes, connections between the browser and the server fail. In my current case, our build monitor needs to be whitelisted on the firewall and sadly has a dynamic IP so every now and then, it loses the connection and the state shown is out of date. 

This PR shows socket.io connection errors in the snackbar to make this problem visible.