### PR TITLE
Group focus view

### DIFF
--- a/client/app.jsx
+++ b/client/app.jsx
@@ -13,13 +13,6 @@ import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 // Setup a socket to pass to components that uses it
 const socket = io();
 
-// When no route is found
-class NoRoute extends React.Component {
-  render() {
-    return <h1>No route found :(</h1>
-  }
-}
-
 // Switch between pipeline and test results page, don't when in admin mode
 const adminMode = window.location.search.indexOf('admin') >= 0;
 if (switchBetweenPagesInterval && switchBetweenPagesInterval > 0 && !adminMode) {

--- a/client/app.jsx
+++ b/client/app.jsx
@@ -43,13 +43,12 @@ ReactDOM.render((
   <MuiThemeProvider theme={theme}>
     <Router>
       <Switch>
-        <Route exact path="/" render={() => (
-          <Main socket={socket} />
-        )} />
         <Route path="/test-results" render={() => (
           <TestResults socket={socket} />
         )} />
-        <Route component={NoRoute} />
+        <Route path="/" render={(props) => (
+          <Main socket={socket} {...props} />
+        )} />
       </Switch>
     </Router>
   </MuiThemeProvider>

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -3,6 +3,7 @@
  */
 
 import React from 'react';
+import { Link } from 'react-router-dom'
 
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
@@ -34,7 +35,8 @@ const sortOrders = [{
   name: 'status',
   label: 'Status (building, failed, cancelled, passed, paused)'
 }];
-
+const groupPath = '/group/';
+const groupRegex = new RegExp(`${groupPath}(.+)$`);
 /**
 * Sort pipelines by date and filter out pipelines without data
 *
@@ -83,6 +85,9 @@ export default class Main extends React.Component {
     super(props, context);
 
     this.socket = props.socket;
+    this.match = props.match;
+    this.location = props.location;
+    this.history = props.history;
 
     // Setup initial state
     this.state = {
@@ -272,7 +277,7 @@ export default class Main extends React.Component {
     ];
 
     let pipelineElements;
-
+    const groupMatch = groupRegex.exec(this.props.location.pathname);
     if (Object.keys(this.state.pipelineNameToGroupName).length < 1) {
       let pipelineCards = this.state.pipelines.map((pipeline) => {
         if (pipeline) {
@@ -302,6 +307,9 @@ export default class Main extends React.Component {
       });
 
       pipelineElements = Object.keys(groupNameToPipelines).map((groupName) => {
+        if (groupMatch && groupMatch[1] != groupName) {
+          return null;
+        }
         let pipelineCards = groupNameToPipelines[groupName].map((pipeline) => {
           if (pipeline) {
             return (
@@ -314,7 +322,7 @@ export default class Main extends React.Component {
         return (
           <div>
             <div className="groupName">
-              {groupName}
+              <Link to={`${groupPath}${groupName}`}>{groupName}</Link>
             </div>
             <div className="row">
               {pipelineCards}
@@ -324,9 +332,18 @@ export default class Main extends React.Component {
       });
     }
 
+    let backButton = null;
+    if (groupMatch) {
+      backButton = (<button
+        onClick={this.props.history.goBack}>
+          Back to all groups
+      </button>);
+    }
+
     return (
       <div className="appcontainer">
         {pipelineElements}
+        {backButton}
         <Dialog
           open={this.state.settingsDialogOpened}
           onClose={this.closeSettings.bind(this)}>

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -85,10 +85,6 @@ export default class Main extends React.Component {
     super(props, context);
 
     this.socket = props.socket;
-    this.match = props.match;
-    this.location = props.location;
-    this.history = props.history;
-
     // Setup initial state
     this.state = {
       // All active pipelines
@@ -334,10 +330,12 @@ export default class Main extends React.Component {
 
     let backButton = null;
     if (groupMatch) {
-      backButton = (<button
-        onClick={this.props.history.goBack}>
+      backButton = (<Button
+        variant="contained"
+        color="primary"
+        onClick={() => this.props.history.push('/')}>
           Back to all groups
-      </button>);
+      </Button>);
     }
 
     return (


### PR DESCRIPTION
Add the ability to click on a pipeline group name to view just that group. This is very useful when there are a lot of pipelines & group that just cannot fit into a single screen.

This also introduces the ability to bookmark a group and rotate between specific group views (e.g. using a browser plugin)

No need to change the configuration, however gocdmonitor_gocd_showbuildlabels should be true to be able to use this feature