### PR TITLE
Make checkPipelinesInterval configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ gocdmonitor_gocd_password=xxx
 Optional environment variables:
 ```
 gocdmonitor_gocd_poll_interval=60
+gocdmonitor_gocd_check_pipelines_interval=60
 gocdmonitor_gocd_showbuildlabels=true
 gocdmonitor_gocd_poll_interval=true
 gocdmonitor_gocd_grouppipelines=true

--- a/app-config.js
+++ b/app-config.js
@@ -19,6 +19,8 @@ var config = {
     goPassword: process.env.gocdmonitor_gocd_password || '',
     // How often data from go should be refreshed in seconds
     goPollingInterval: process.env.gocdmonitor_gocd_poll_interval || 30,
+    // How often pipeline structure data should be refreshed in seconds
+    goCheckPipelinesInterval: process.env.gocdmonitor_gocd_check_pipelines_interval || 24 * 60 * 60,
     // If > 0 switches between pipeline and test results page every n seconds
     switchBetweenPagesInterval: process.env.gocdmonitor_gocd_poll_interval || 0,
     // Whether to display build labels

--- a/server/services/GoService.js
+++ b/server/services/GoService.js
@@ -21,7 +21,7 @@ export default class GoService {
     };
     this.pollingInterval = conf.goPollingInterval * 1000;
     // Refresh pipelines once every day
-    this.checkPipelinesInterval = 24 * 60 * 60 * 1000;
+    this.checkPipelinesInterval = conf.goCheckPipelinesInterval * 1000;
     this.buildService = new GoBuildService(this.goConfig);
     this.testService = new GoTestService(this.goConfig);
 


### PR DESCRIPTION
The current `checkPipelinesInterval` of once a day might be a good value for teams where the pipelines don't change much but is confusing or annoying for teams that add or change pipelines more often.

This PR makes this value configurable, leaving the default value as it was. 