### PR TITLE
Fix crash on first admin UI save

### DIFF
--- a/server/services/DBService.js
+++ b/server/services/DBService.js
@@ -19,7 +19,10 @@ export default class DBService {
    */
   saveOrUpdateSettings(settings) {
     const insertSettings = () => {
-      return this._executeDbAction('insert', { settings: settings })
+      return this._executeDbAction('insert', { settings: settings }).then(() => {
+          // Since callback of an insert returns the complete document, we resolve with settings argument
+          return settings;
+      });
     }
     return this.getSettings().then((doc) => {
       if (doc && doc.settings) {


### PR DESCRIPTION
Looks like the DB insert and update operations return different documents leading the app to crash the first time it runs. This PR fixes this. 

Steps to reproduce: 

* Start the server from a clean slate (`$ rm server/data.db && npm run dev-start`)
* Go to the admin-UI, save the config
* Wait for the next `refreshPipelines` poll, server crashes: 
  ```
  TypeError: Cannot read property 'indexOf' of undefined
    at /Users/fsellmay/Code/gocd-monitor/server/services/GoService.js:56:76
    at Array.filter (<anonymous>)
    at Timeout.refreshPipelines [as _onTimeout] (/Users/fsellmay/Code/gocd-monitor/server/services/GoService.js:56:46)
    at ontimeout (timers.js:427:13)
    at tryOnTimeout (timers.js:289:5)
    at listOnTimeout (timers.js:252:5)
    at Timer.processTimers (timers.js:212:10)
  ```
* Start the server again, this time with the data already stored (`$npm run dev-start`)
* Go to the admin-UI, save the config again
* Server doesn't crash anymore