### PR TITLE
Make UI config defaults configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ gocdmonitor_gocd_showbuildlabels=true
 gocdmonitor_gocd_poll_interval=true
 gocdmonitor_gocd_grouppipelines=true
 gocdmonitor_gocd_linktopipelineingo=true
+gocdmonitor_default_sort_order=buildtime
+gocdmonitor_default_hidden_pipelines=foo,bar
 ```
 
 Enabling HTTPS of the server

--- a/app-config.js
+++ b/app-config.js
@@ -26,6 +26,10 @@ var config = {
     // Whether to group pipelines
     groupPipelines: process.env.gocdmonitor_gocd_grouppipelines === "true",
     // Whether to link to pipeline in GoCD on click
-    linkToPipelineInGo: process.env.gocdmonitor_gocd_linktopipelineingo === 'true'
+    linkToPipelineInGo: process.env.gocdmonitor_gocd_linktopipelineingo === 'true',
+    // How to sort pipelines by default (buildtime, status) - can be overridden in the admin UI
+    defaultSortOrder: process.env.gocdmonitor_default_sort_order || 'buildtime',
+    // Which pipelines to hide - can be overridden in the admin UI
+    defaultDisabledPipelines: (process.env.gocdmonitor_default_hidden_pipelines || "").split(",").filter((val) => val) || []
 }
 module.exports = config;

--- a/server/services/GoService.js
+++ b/server/services/GoService.js
@@ -17,7 +17,8 @@ export default class GoService {
     this.pipelinesPauseInfo = {};
     this.testResults = [];
     this.currentSettings = {
-      disabledPipelines: []
+      disabledPipelines: conf.defaultDisabledPipelines,
+      sortOrder: conf.defaultSortOrder
     };
     this.pollingInterval = conf.goPollingInterval * 1000;
     // Refresh pipelines once every day
@@ -37,7 +38,7 @@ export default class GoService {
     // Retrieve current settings
     this.dbService.getSettings().then((doc) => {
       if (doc && doc.settings) {
-        this.currentSettings = doc.settings;
+        this.currentSettings = Object.assign(this.currentSettings, doc.settings);
       }
     });
 


### PR DESCRIPTION
The default sort order and disabled pipelines configuration is currently configured through the UI and then stored in the database. Since my team runs the build-monitor on an immutable server without persistent storage, this configuration gets lost whenever we re-deploy. 

This PR introduces a way to configure defaults through the config file or environment variables, allowing users to configure these values without clicking in the UI and without requiring persistent storage. Configuration made through the UI and stored in the DB still overrides these defaults.