### PR TITLE
Add client-side variables to webpack and read them from process.env

### DIFF
--- a/client/components/Pipeline.jsx
+++ b/client/components/Pipeline.jsx
@@ -9,7 +9,11 @@ import CardContent from '@material-ui/core/CardContent';
 import * as Colors from '@material-ui/core/colors';
 import Typography from '@material-ui/core/Typography';
 
-import { goServerUrl, showBuildLabels, linkToPipelineInGo, hideWeatherIcons } from '../../app-config';
+import { goServerUrl } from '../../app-config';
+
+const showBuildLabels = process.env.SHOW_BUILD_LABELS;
+const linkToPipelineInGo = process.env.LINK_TO_PIPELINE_IN_GO;
+const hideWeatherIcons = process.env.HIDE_WEATHER_ICONS;
 
 const pipelineHistoryUrl = goServerUrl + '/go/tab/pipeline/history/';
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -21,7 +21,10 @@ module.exports = {
     new webpack.DefinePlugin({
       "process.env": {
         ENABLE_DARK_THEME: conf.enableDarkTheme,
-        SWITCH_BETWEEN_PAGES_INTERVAL: conf.switchBetweenPagesInterval
+        SWITCH_BETWEEN_PAGES_INTERVAL: conf.switchBetweenPagesInterval,
+        SHOW_BUILD_LABELS: conf.showBuildLabels,
+        LINK_TO_PIPELINE_IN_GO: conf.linkToPipelineInGo,
+        HIDE_WEATHER_ICONS: conf.hideWeatherIcons
       }
     }),
     // Ignore all locale files of moment.js


### PR DESCRIPTION
Setting the env variables `gocdmonitor_gocd_showbuildlabels`, `gocdmonitor_gocd_linktopipelineingo` and `gocdmonitor_hide_weather_icons` had no effect on the monitor, because they weren't available in the process.env of the client.