### PR TITLE
Make DB path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ gocdmonitor_enable_dark_theme=true
 gocdmonitor_gocd_showbuildlabels=true
 gocdmonitor_gocd_linktopipelineingo=true
 gocdmonitor_gocd_hide_weather_icons=true
+gocdmonitor_db_file_path=server/data.db
 ```
 
 Enabling HTTPS of the server

--- a/app-config.js
+++ b/app-config.js
@@ -29,6 +29,8 @@ var config = {
     defaultSortOrder: process.env.gocdmonitor_default_sort_order || 'buildtime',
     // Which pipelines to hide - can be overridden in the admin UI
     defaultDisabledPipelines: (process.env.gocdmonitor_default_hidden_pipelines || "").split(",").filter((val) => val) || [],
+    // Where to store the database file
+    dbFilePath: process.env.gocdmonitor_db_file_path || 'server/data.db',
 
     // --- Client ---
     // Enable dark theme

--- a/server/services/DBService.js
+++ b/server/services/DBService.js
@@ -2,8 +2,8 @@ import Datastore from 'nedb';
 
 export default class DBService {
 
-  constructor() {
-    this.datastore = new Datastore({ filename: 'server/data.db', autoload: true });
+  constructor(conf) {
+    this.datastore = new Datastore({ filename: conf.dbFilePath, autoload: true });
   }
 
   /**

--- a/server/services/DBService.js
+++ b/server/services/DBService.js
@@ -2,8 +2,8 @@ import Datastore from 'nedb';
 
 export default class DBService {
 
-  constructor(conf) {
-    this.datastore = new Datastore({ filename: conf.dbFilePath, autoload: true });
+  constructor(dbFilePath) {
+    this.datastore = new Datastore({ filename: dbFilePath, autoload: true });
   }
 
   /**

--- a/server/services/GoService.js
+++ b/server/services/GoService.js
@@ -27,7 +27,7 @@ export default class GoService {
     this.testService = new GoTestService(this.goConfig);
 
     // Init db and settings
-    this.dbService = new DBService();
+    this.dbService = new DBService(conf);
 
   }
 

--- a/server/services/GoService.js
+++ b/server/services/GoService.js
@@ -27,7 +27,7 @@ export default class GoService {
     this.testService = new GoTestService(this.goConfig);
 
     // Init db and settings
-    this.dbService = new DBService(conf);
+    this.dbService = new DBService(conf.dbFilePath);
 
   }
 


### PR DESCRIPTION
When running GoCD Monitor inside a Docker container, the DB state can currently not be persisted in a Docker volume for two reasons: 
* the DB file is stored in `server/`, together with lots of other files so volume-mounting into that directory would overwrite all other files
* volume-mounting just the file (e.g. `-v /tmp/data.db:/usr/src/app/server/data.db`) seems to make `nedb` unhappy (`EBUSY: resource busy or locked`)

Using a DB file from a directory without any application files would fix this issue. To preserve backwards-compatibility, this PR adds the option to do this by adding a configuration setting `gocdmonitor_db_file_path` to supply an alternate path to the DB file. 

This can also be helpful in situations where one wants to run several instances using different configuration settings. 