### PR TITLE
Proposal: Add configuration profiles to support multiple teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Go to `http://localhost:3000?admin` and click the settings button in the bottom-
 * Filter Pipelines - Disable/enable pipelines to retrieve from go server. It's also possible to write a regex with the pipelines you want.
 ![Configuration](https://github.com/karmats/gocd-monitor/blob/gh-pages/images/configuration.png?raw=true)
 
+### Using multiple configuration profiles
+
+Add the `profile` attribute to your URL, e.g. `http://localhost:3000?admin&profile=team1`. Then continue to configure as usual.
+
 ## Test reports
 To configure test reports, go to `http://localhost:3000/test-results?admin`. Click the '+'-button and choose the pipeline you want to generate test reports for. The system then retrieves all test files and creates graph and possible error table for all tests found in that pipeline. For now only cucumber tests are supported. If defined, the system will switch between monitor and test report page every `switchBetweenPagesInterval` seconds.
 ![Test reports](https://github.com/karmats/gocd-monitor/blob/gh-pages/images/test-report.png?raw=true)

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -318,7 +318,7 @@ export default class Main extends React.Component {
         return (
           <div>
             <div className="groupName">
-              <Link to={`${groupPath}${groupName}`}>{groupName}</Link>
+              <Link to={`${groupPath}${groupName}${window.location.search}`}>{groupName}</Link>
             </div>
             <div className="row">
               {pipelineCards}
@@ -333,7 +333,7 @@ export default class Main extends React.Component {
       backButton = (<Button
         variant="contained"
         color="primary"
-        onClick={() => this.props.history.push('/')}>
+        onClick={() => this.props.history.push(`/${window.location.search}`)}>
           Back to all groups
       </Button>);
     }

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -7,8 +7,9 @@ import { grey, purple } from '@material-ui/core/colors';
 import Main from './components/Main';
 import TestResults from './components/TestResults';
 
-// Setup a socket to pass to components that uses it
-const socket = io(window.location.href);
+// Setup a socket to pass to components that uses it;
+// use the host only, to support group URLs and pass on query parameters for configuration
+const socket = io(window.location.protocol + '//' + window.location.host + window.location.search);
 
 // Switch between pipeline and test results page, don't when in admin mode
 const adminMode = window.location.search.indexOf('admin') >= 0;

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -8,7 +8,7 @@ import Main from './components/Main';
 import TestResults from './components/TestResults';
 
 // Setup a socket to pass to components that uses it
-const socket = io();
+const socket = io(window.location.href);
 
 // Switch between pipeline and test results page, don't when in admin mode
 const adminMode = window.location.search.indexOf('admin') >= 0;

--- a/server/services/DBService.js
+++ b/server/services/DBService.js
@@ -19,6 +19,13 @@ export default class DBService {
   }
 
   /**
+   * @return {Promise<boolean>}           true if the database contains saved settings for a profile
+   */
+  numberOfSettingsWithProfile() {
+    return this._executeDbAction('count', {profile: {$exists: true}});
+  }
+
+  /**
    * @param {string}          profile    The new settings to save or update
    * @param {Object}          settings   The new settings to save or update
    * @return {Promise<Object>}           The updated settings

--- a/server/services/DBService.js
+++ b/server/services/DBService.js
@@ -7,27 +7,33 @@ export default class DBService {
   }
 
   /**
-   * @return {Promise<Object>}  Settings stored in db
+   * @param {string}           profile   Name of the settings profile
+   * @return {Promise<Object>}           Settings stored in db
    */
-  getSettings() {
-    return this._executeDbAction('findOne', { settings: { $exists: true } });
+  getSettings(profile) {
+    if (profile) {
+      return this._executeDbAction('findOne',{$and: [{settings: {$exists: true}}, {profile: profile}]});
+    } else {
+      return this._executeDbAction('findOne',{$and: [{settings: {$exists: true}}, {profile: {$exists: false}}]});
+    }
   }
 
   /**
+   * @param {string}          profile    The new settings to save or update
    * @param {Object}          settings   The new settings to save or update
    * @return {Promise<Object>}           The updated settings
    */
-  saveOrUpdateSettings(settings) {
+  saveOrUpdateSettings(profile, settings) {
     const insertSettings = () => {
-      return this._executeDbAction('insert', { settings: settings }).then(() => {
+      return this._executeDbAction('insert', { settings: settings, profile }).then(() => {
           // Since callback of an insert returns the complete document, we resolve with settings argument
           return settings;
       });
     }
-    return this.getSettings().then((doc) => {
+    return this.getSettings(profile).then((doc) => {
       if (doc && doc.settings) {
         return this._executeDbAction('update', { _id: doc._id }, { $set: { settings: settings } }, {}).then(() => {
-          // Since callback of an update returns number of affected documents, we resolve with settings argument 
+          // Since callback of an update returns number of affected documents, we resolve with settings argument
           return settings;
         });
       } else {
@@ -78,7 +84,7 @@ export default class DBService {
 
   /**
    * Executes a database action
-   * 
+   *
    * @param   {string}        action    The action to execute e.g. find, update, remove etc
    * @parma   {Array<Object>} args      Database arguments
    */

--- a/server/services/GoService.js
+++ b/server/services/GoService.js
@@ -5,7 +5,6 @@ import GoTestService from './GoTestService';
 import DBService from './DBService';
 import Logger from '../utils/Logger';
 import CucumberParser from '../utils/CucumberParser';
-import _ from 'lodash'
 
 export default class GoService {
 
@@ -355,8 +354,9 @@ export default class GoService {
    * @param {Object}  data    The data to send
    */
   notifyAllClientsWithProfile(profile, event, data) {
-    const clientsWithProfile = _.groupBy(this.clients, this.profileForClient)[profile] || []
-    clientsWithProfile.forEach((client) => {
+    this.clients.filter((client) => {
+      return this.profileForClient(client) === profile
+    }).forEach((client) => {
       client.emit(event, data);
     });
   }

--- a/server/services/GoService.js
+++ b/server/services/GoService.js
@@ -46,8 +46,13 @@ export default class GoService {
   currentSettings(profile) {
     return this.dbService.getSettings(profile).then((doc) => {
       if (doc && doc.settings) {
+        // saved settings exist, merge them with default settings
         return Object.assign({}, this.defaultSettings, doc.settings);
+      } else if (profile !== null) {
+        // no saved settings exist for a profile; fall back to settings for default profile
+        return this.currentSettings(null)
       } else {
+        // no settings exist for default profile; fall back to default settings from the config
         return this.defaultSettings
       }
     });

--- a/spec/GoServiceSpec.js
+++ b/spec/GoServiceSpec.js
@@ -10,6 +10,8 @@ describe('GoService spec', () => {
   chai.use(chaiAsPromised);
   const expect = chai.expect;
 
+  const clientStub = () => {return {id: 'client1', on: () => {}, emit: () => {}, handshake: { query: { }}}};
+
   const goService = new GoService();
 
   describe('#constructor()', () => {
@@ -29,14 +31,14 @@ describe('GoService spec', () => {
     it('should register a client', (done) => {
       expect(goService.clients).to.have.lengthOf(0);
 
-      goService.registerClient({ id: 'client1', on: () => { }, emit: () => { } });
+      goService.registerClient(clientStub());
       expect(goService.clients).to.have.lengthOf(1);
 
       done();
     });
 
     it('should not register client if client is already registered', (done) => {
-      let client = { id: 'client1', on: () => { }, emit: () => { } };
+      let client = clientStub();
 
       goService.registerClient(client);
       expect(goService.clients).to.have.lengthOf(1);
@@ -47,7 +49,7 @@ describe('GoService spec', () => {
     });
 
     it('should unregister a client', (done) => {
-      let client = { id: 'client1', on: () => { }, emit: () => { } };
+      let client = clientStub();
 
       goService.registerClient(client);
       expect(goService.clients).to.have.lengthOf(1);
@@ -59,7 +61,7 @@ describe('GoService spec', () => {
     });
 
     it('should not affect client list if a client that does not exists is unregistered', (done) => {
-      let client = { id: 'client1', on: () => { }, emit: () => { } };
+      let client = clientStub();
 
       expect(goService.clients).to.have.lengthOf(0);
       goService.unregisterClient(client);


### PR DESCRIPTION
This PR is a proposal how #53 could be resolved. It adds the `profile` argument to the URL, allowing users to switch between as many sets of configurations as they like. 

Notes for the review:
* This PR removes two optimisations: 
  * Previously, settings-information was kept in memory. This PR changes this to go back to the DB for every request so makes performance/load a bit worse. I don't think this is a big deal for the kind of workload we are looking at (few, long-running clients) but if you have doubts and feel it's worth the extra complexity, let me know and we can add some caching
  * Previously, disabled pipelines were not fetched from GoCD. I can see how this can reduce load on GoCD if there are a lot of pipelines. However, I'd guess in most cases, someone would be interested in most of those pipelines so they'd need to be fetched anyway. But if you feel there is enough of a case to keep this optimisation, I could think of a solution where we aggregate the disabled pipelines in all the settings and then filter for those. 
