### PR TITLE
Show card details in black when using dark theme

### DIFF
--- a/client/components/Pipeline.jsx
+++ b/client/components/Pipeline.jsx
@@ -13,13 +13,14 @@ const goServerUrl = process.env.GO_SERVER_URL;
 const showBuildLabels = process.env.SHOW_BUILD_LABELS;
 const linkToPipelineInGo = process.env.LINK_TO_PIPELINE_IN_GO;
 const hideWeatherIcons = process.env.HIDE_WEATHER_ICONS;
+const enableDarkTheme = process.env.ENABLE_DARK_THEME;
 
 const pipelineHistoryUrl = goServerUrl + '/go/tab/pipeline/history/';
 
 // Weather icon indicator
 const weatherIconStatuses = ['sunny', 'partlycloudy', 'cloudy', 'cloudy', 'pouring', 'lightning'];
 
-const white = '#fff';
+const fontColor = enableDarkTheme ? '#000': '#fff';
 const styles = {
   cardSuccess: {
     background: Colors.green.A700,
@@ -46,20 +47,29 @@ const styles = {
     paddingBottom: '0.5rem'
   },
   cardTitle: {
-    color: white,
+    color: fontColor,
     fontSize: '1.2em'
   },
   cardLabel: {
     fontWeight: 'normal'
   },
   cardSubTitle: {
-    color: white,
+    color: fontColor,
     fontSize: '1em',
     fontWeight: 100
   },
   progress: {
-    color: white,
+    color: fontColor,
     float: 'right'
+  },
+  buildInfo: {
+    color: fontColor
+  },
+  weatherIcon: {
+    color: fontColor
+  },
+  loader: {
+    stroke: fontColor
   }
 };
 
@@ -154,7 +164,7 @@ export default class Pipeline extends React.Component {
               if (stage.status === 'building') {
                 return (<span key={stage.name} className="loader">
                   <svg className="circular" viewBox="25 25 50 50">
-                    <circle className="path" cx="50" cy="50" r="20" fill="none" strokeWidth="4" strokeMiterlimit="10" />
+                    <circle className="path" cx="50" cy="50" r="20" fill="none" strokeWidth="4" strokeMiterlimit="10" style={styles.loader} />
                   </svg>
                 </span>);
               } else {
@@ -194,13 +204,13 @@ export default class Pipeline extends React.Component {
           {pipeline.name}
         </Typography>
         {!hideWeatherIcons &&
-          <i className={'mdi-weather-' + this.weatherIcon(pipeline) + ' mdi mdi-48px buildstatus'}></i>
+          <i className={'mdi-weather-' + this.weatherIcon(pipeline) + ' mdi mdi-48px buildstatus'} style={styles.weatherIcon}></i>
         }
         <Typography style={styles.cardSubTitle} color="textSecondary">
           {buildStatus}
         </Typography>
 
-        <div className="buildinfo">
+        <div className="buildinfo" style={styles.buildInfo}>
           <div className="col-xs-6">
             <p>
               <i className="mdi mdi-clock-outline mdi-24px"></i>


### PR DESCRIPTION
Reasons why I made card details to be in black color when using the dark theme:

1. I find it difficult to read white text on green, red colors
2. In dark theme mode,  white color text looks weird

Screenshot:

<img width="1252" alt="Screenshot 2019-09-12 at 1 21 43 AM" src="https://user-images.githubusercontent.com/6568319/64730433-f80d9e80-d4fc-11e9-9f3d-31d89564bbfe.png">

Let me know if this change makes sense.