### PR TITLE
Update readme with local GoCD setup for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,11 @@ To configure test reports, go to `http://localhost:3000/test-results?admin`. Cli
 The server polls the go server every `goPollingInterval` seconds. The results are then reported to the client using [socket.io](http://socket.io/). The pipelines and its pause info are refreshed once every day.
 
 ## Development
-To run the application in development mode, open a terminal and enter `npm run dev-start`. The server and client will be rebuilt when a js or jsx-file changes.
+
+[gocd-trial-launcher](https://www.gocd.org/test-drive-gocd.html) can be used to setup GoCD locally with sample piplines. Download and extract the appropriate archive for your development environment. Enter `./run-gocd` to start the setup.
+
+To run the application in development mode, open a terminal and enter `npm run dev-start`. The server and client will be rebuilt when a js or jsx-file changes. By default, it points to the GoCD server started by gocd-trial-launcher ([refer](https://github.com/karmats/gocd-monitor/blob/1aad6e45c3f5454f0e4f2857f64a1055a13ea459/app-config.js#L15)).
+
 To run tests, enter `npm test`.
 
 ## Troubleshooting

--- a/app-config.js
+++ b/app-config.js
@@ -12,7 +12,7 @@ var config = {
     // Key for https
     httpsKeyPath: process.env.gocdmonitor_key_path || './server/cert/server.key',
     // Url for your go server
-    goServerUrl: process.env.gocdmonitor_gocd_host || 'https://ci.example.com',
+    goServerUrl: process.env.gocdmonitor_gocd_host || 'http://localhost:8153',
     // Go user to use for communication with go server
     goUser: process.env.gocdmonitor_gocd_user || '',
     // Password for go user


### PR DESCRIPTION
* Suggest using [gocd-trial-launcher](https://www.gocd.org/test-drive-gocd.html) for local GoCD setup
* Update app config to point to local GoCD server by default